### PR TITLE
use quotes for template expressions when starting a value

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: rebuild buildroot
-  shell: {{ atomic_reactor_rpm.buildroot_cmd }}
+  shell: "{{ atomic_reactor_rpm.buildroot_cmd }}"


### PR DESCRIPTION
This fixes an error I saw:

```
ERROR: Syntax Error while loading YAML script, /home/twaugh/devel/ansible-osbs/roles/atomic-reactor/handlers/main.yml
Note: The error may actually appear before this position: line 3, column 11

- name: rebuild buildroot
  shell: {{ atomic_reactor_rpm.buildroot_cmd }}
          ^
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"
```
